### PR TITLE
Add Common Group Data Mappings For Initial Release

### DIFF
--- a/switmt_to_iso20022/constant_variables.bal
+++ b/switmt_to_iso20022/constant_variables.bal
@@ -1,6 +1,11 @@
 const DETAILS_CHRGS = [["BEN", "CRED"], ["OUR", "DEBT"], ["SHA", "SHAR"]];
 const DEFAULT_NUM_OF_TX = "1";
 const YEAR_PREFIX = "20";
+const ASSIGN_ID = "ASSIGNID-01";
+const REASON_CODE = ["AGNT", "AM09", "COVR", "CURR", "CUST", "CUTA", "DUPL", "FRAD", "TECH", "UPAY"];
+const MISSING_INFO_CODE = ["3", "4", "5", "7", "10", "13", "14", "15", "16", "17", "18", "19", "23", "24", "25", "26", "27", "28", "29", "36", "37", "38", "42", "48", "49", "50", "51"];
+const INCORRECT_INFO_CODE = ["2", "6", "8", "9", "11", "12", "20", "22", "39", "40", "41", "43", "44", "45", "46", "47"];
+const map<string> INVTGTN_RJCT_RSN = {"RQDA": "NAUT", "LEGL": "NAUT", "INDM": "NAUT", "AGNT": "NAUT", "CUST": "NAUT", "NOOR": "NFND", "PTNA": "UKNW", "ARPL": "UKNW", "NOAS": "UKNW", "AM04": "PCOR", "AC04": "PCOR", "ARDT": "UKNW"};
 final readonly & map<isolated function (record {} message) returns record {}|error> transformFunctionMap =
     {
     "101": transformMT101,
@@ -10,6 +15,8 @@ final readonly & map<isolated function (record {} message) returns record {}|err
     "103STP": transformMT103STP,
     "103REMIT": transformMT103REMIT,
     "107": transformMT107,
+    "192": transformMT192ToCamt055,
+    "195": transformMTn92ToCamt056,
     "200": transformMT200ToPacs009,
     "201": transformMT201,
     "202": transformMT202,
@@ -19,6 +26,8 @@ final readonly & map<isolated function (record {} message) returns record {}|err
     "205": transformMT205,
     "205COV": transformMT205COV,
     "210": transformMT210,
+    "292": transformMTn92ToCamt056,
+    "295": transformMTn92ToCamt056,
     "900": transformMT900,
     "910": transformMT910,
     "920": transformMT920,
@@ -27,5 +36,7 @@ final readonly & map<isolated function (record {} message) returns record {}|err
     "970": transformMT970,
     "971": transformMT971,
     "972": transformMT972,
-    "973": transformMT973
+    "973": transformMT973,
+    "992": transformMTn92ToCamt056,
+    "995": transformMTn92ToCamt056
 };


### PR DESCRIPTION
## Purpose
Introduce data mappings for SWIFT MT N group messages. These mappings will provide a unified structure, ensuring consistency and accuracy in data representation across various message types in this group.

## Goals
Implementing core mappings that support standardization to simplify future expansions and enhances interoperability between systems processing SWIFT MT messages in the N group, enabling seamless data transformation and integration.